### PR TITLE
fix GetObject WithRelations

### DIFF
--- a/pkg/directory/v3/writer.go
+++ b/pkg/directory/v3/writer.go
@@ -87,8 +87,8 @@ func (s *Writer) DeleteObject(ctx context.Context, req *dsw3.DeleteObjectRequest
 					return err
 				}
 
-				rel := ds.Relation(iter.Value())
 				for iter.Next() {
+					rel := ds.Relation(iter.Value())
 					if err := bdb.Delete(ctx, tx, bdb.RelationsObjPath, rel.ObjKey()); err != nil {
 						return err
 					}
@@ -105,8 +105,9 @@ func (s *Writer) DeleteObject(ctx context.Context, req *dsw3.DeleteObjectRequest
 					return err
 				}
 
-				rel := ds.Relation(iter.Value())
 				for iter.Next() {
+					rel := ds.Relation(iter.Value())
+
 					if err := bdb.Delete(ctx, tx, bdb.RelationsObjPath, rel.ObjKey()); err != nil {
 						return err
 					}


### PR DESCRIPTION
fix refactor regression, which used iter.Value() outside the for iter.Next() block