### PR TITLE
Fix If-None-Match handling in GetManifest

### DIFF
--- a/pkg/directory/v3/model.go
+++ b/pkg/directory/v3/model.go
@@ -83,7 +83,7 @@ func (s *Model) GetManifest(req *dsm3.GetManifestRequest, stream dsm3.Model_GetM
 		}
 
 		inMD, _ := metadata.FromIncomingContext(stream.Context())
-		if lo.Contains(inMD.Get(headers.IfNoneMatch), md.Etag) {
+		if lo.Contains(inMD.Get(headers.IfNoneMatch), manifest.Metadata.Etag) {
 			return nil
 		}
 


### PR DESCRIPTION
It was comparing the value of the header to an ETag that's always empty.