### PR TITLE
Validate objects

### DIFF
--- a/pkg/bdb/migrate/mig/mig.go
+++ b/pkg/bdb/migrate/mig/mig.go
@@ -85,7 +85,7 @@ func CreateBucket(path bdb.Path) func(*zerolog.Logger, *bolt.DB, *bolt.DB) error
 
 func DeleteBucket(path bdb.Path) func(*zerolog.Logger, *bolt.DB, *bolt.DB) error {
 	return func(log *zerolog.Logger, _ *bolt.DB, rwDB *bolt.DB) error {
-		log.Info().Str("path", strings.Join(path, "/")).Msg("CreateBucket")
+		log.Info().Str("path", strings.Join(path, "/")).Msg("DeleteBucket")
 
 		if err := rwDB.Update(func(tx *bolt.Tx) error {
 			if len(path) == 1 {

--- a/pkg/ds/check.go
+++ b/pkg/ds/check.go
@@ -36,24 +36,24 @@ func (i *check) Subject() *dsc3.ObjectIdentifier {
 	}
 }
 
-func (i *check) Validate(mc *cache.Cache) (bool, error) {
+func (i *check) Validate(mc *cache.Cache) error {
 	if i == nil || i.CheckRequest == nil {
-		return false, ErrInvalidRequest.Msg("check")
+		return ErrInvalidRequest.Msg("check")
 	}
 
 	if !mc.ObjectExists(model.ObjectName(i.ObjectType)) {
-		return false, ErrObjectNotFound.Msgf("object_type: %s", i.ObjectType)
+		return ErrObjectNotFound.Msgf("object_type: %s", i.ObjectType)
 	}
 
 	if !mc.ObjectExists(model.ObjectName(i.SubjectType)) {
-		return false, ErrObjectNotFound.Msgf("subject_type: %s", i.SubjectType)
+		return ErrObjectNotFound.Msgf("subject_type: %s", i.SubjectType)
 	}
 
 	if !mc.RelationExists(model.ObjectName(i.ObjectType), model.RelationName(i.Relation)) {
-		return false, ErrRelationNotFound.Msgf("relation: %s%s%s", i.ObjectType, RelationSeparator, i.Relation)
+		return ErrRelationNotFound.Msgf("relation: %s%s%s", i.ObjectType, RelationSeparator, i.Relation)
 	}
 
-	return true, nil
+	return nil
 }
 
 func (i *check) Exec(ctx context.Context, tx *bolt.Tx, mc *cache.Cache) (*dsr3.CheckResponse, error) {

--- a/pkg/ds/check_permission.go
+++ b/pkg/ds/check_permission.go
@@ -36,24 +36,24 @@ func (i *checkPermission) Subject() *dsc3.ObjectIdentifier {
 	}
 }
 
-func (i *checkPermission) Validate(mc *cache.Cache) (bool, error) {
+func (i *checkPermission) Validate(mc *cache.Cache) error {
 	if i == nil || i.CheckPermissionRequest == nil {
-		return false, ErrInvalidRequest.Msg("check_permission")
+		return ErrInvalidRequest.Msg("check_permission")
 	}
 
-	if ok, err := ObjectIdentifier(i.Object()).Validate(); !ok {
-		return ok, err
+	if err := ObjectIdentifier(i.Object()).Validate(mc); err != nil {
+		return err
 	}
 
-	if ok, err := ObjectIdentifier(i.Subject()).Validate(); !ok {
-		return ok, err
+	if err := ObjectIdentifier(i.Subject()).Validate(mc); err != nil {
+		return err
 	}
 
 	if !mc.PermissionExists(model.ObjectName(i.ObjectType), model.RelationName(i.Permission)) {
-		return false, ErrPermissionNotFound.Msgf("%s%s%s", i.ObjectType, RelationSeparator, i.Permission)
+		return ErrPermissionNotFound.Msgf("%s%s%s", i.ObjectType, RelationSeparator, i.Permission)
 	}
 
-	return true, nil
+	return nil
 }
 
 func (i *checkPermission) Exec(ctx context.Context, tx *bolt.Tx, mc *cache.Cache) (*dsr3.CheckPermissionResponse, error) {

--- a/pkg/ds/check_relation.go
+++ b/pkg/ds/check_relation.go
@@ -42,24 +42,24 @@ func (i *checkRelation) Subject() *dsc3.ObjectIdentifier {
 	}
 }
 
-func (i *checkRelation) Validate(mc *cache.Cache) (bool, error) {
+func (i *checkRelation) Validate(mc *cache.Cache) error {
 	if i == nil || i.CheckRelationRequest == nil {
-		return false, ErrInvalidRequest.Msg("check_relation")
+		return ErrInvalidRequest.Msg("check_relation")
 	}
 
-	if ok, err := ObjectIdentifier(i.Object()).Validate(); !ok {
-		return ok, err
+	if err := ObjectIdentifier(i.Object()).Validate(mc); err != nil {
+		return err
 	}
 
-	if ok, err := ObjectIdentifier(i.Subject()).Validate(); !ok {
-		return ok, err
+	if err := ObjectIdentifier(i.Subject()).Validate(mc); err != nil {
+		return err
 	}
 
 	if !mc.RelationExists(model.ObjectName(i.ObjectType), model.RelationName(i.Relation)) {
-		return false, ErrRelationNotFound.Msgf("%s%s%s", i.ObjectType, RelationSeparator, i.Relation)
+		return ErrRelationNotFound.Msgf("%s%s%s", i.ObjectType, RelationSeparator, i.Relation)
 	}
 
-	return true, nil
+	return nil
 }
 
 func (i *checkRelation) Exec(ctx context.Context, tx *bolt.Tx, mc *cache.Cache) (*dsr3.CheckRelationResponse, error) {


### PR DESCRIPTION
When wiring in the v3 proto validation, we left things in a weird state.
Some of the previous validation logic was no longer called even though it is necessary.

This PR updates all endpoints with proper input validation.