### PR TITLE
Move model update to a db migration.

### DIFF
--- a/pkg/bdb/migrate/mig004/migrate.go
+++ b/pkg/bdb/migrate/mig004/migrate.go
@@ -1,0 +1,65 @@
+package mig004
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/aserto-dev/azm/model"
+	v3 "github.com/aserto-dev/azm/v3"
+	dsm3 "github.com/aserto-dev/go-directory/aserto/directory/model/v3"
+	"github.com/aserto-dev/go-edge-ds/pkg/bdb"
+	"github.com/rs/zerolog"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+// mig004
+//
+// load model from manifest and write it back to the db.
+const (
+	Version string = "0.0.4"
+)
+
+func Migrate(log *zerolog.Logger, roDB, rwDB *bolt.DB) error {
+	logger := log.With().Str("version", Version).Logger()
+	logger.Info().Msg("StartMigration")
+
+	// skip when roDB is nil.
+	if roDB == nil {
+		logger.Debug().Msg("SKIP")
+		return nil
+	}
+
+	ctx := context.Background()
+	m, err := loadModel(ctx, roDB)
+	if err != nil {
+		return err
+	}
+
+	if err := rwDB.Update(func(tx *bolt.Tx) error {
+		_, err := bdb.SetAny[model.Model](ctx, tx, bdb.ManifestPath, bdb.ModelKey, m)
+		return err
+	}); err != nil {
+		return err
+	}
+
+	logger.Info().Msg("FinishedMigration")
+	return nil
+}
+
+func loadModel(ctx context.Context, roDB *bolt.DB) (*model.Model, error) {
+	var m *model.Model
+	if err := roDB.View(func(rtx *bolt.Tx) error {
+		manifestBody, err := bdb.Get[dsm3.Body](ctx, rtx, bdb.ManifestPath, bdb.BodyKey)
+		if err != nil {
+			return err
+		}
+
+		m, err = v3.Load(bytes.NewReader(manifestBody.Data))
+		return err
+	}); err != nil {
+		return m, err
+	}
+
+	return m, nil
+}

--- a/pkg/bdb/migrate/migrate.go
+++ b/pkg/bdb/migrate/migrate.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aserto-dev/go-edge-ds/pkg/bdb/migrate/mig001"
 	"github.com/aserto-dev/go-edge-ds/pkg/bdb/migrate/mig002"
 	"github.com/aserto-dev/go-edge-ds/pkg/bdb/migrate/mig003"
+	"github.com/aserto-dev/go-edge-ds/pkg/bdb/migrate/mig004"
 	"github.com/aserto-dev/go-edge-ds/pkg/fs"
 
 	"github.com/Masterminds/semver"
@@ -25,6 +26,7 @@ var migMap = map[string]Migration{
 	mig001.Version: mig001.Migrate,
 	mig002.Version: mig002.Migrate,
 	mig003.Version: mig003.Migrate,
+	mig004.Version: mig004.Migrate,
 }
 
 var (

--- a/pkg/bdb/model.go
+++ b/pkg/bdb/model.go
@@ -1,11 +1,9 @@
 package bdb
 
 import (
-	"bytes"
-	"encoding/json"
+	"context"
 
 	"github.com/aserto-dev/azm/model"
-	v3 "github.com/aserto-dev/azm/v3"
 	bolt "go.etcd.io/bbolt"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -15,35 +13,19 @@ import (
 // and swaps the model instance in the cache.Cache using
 // cache.UpdateModel.
 func (s *BoltDB) LoadModel() error {
+	ctx := context.Background()
+
 	err := s.db.View(func(tx *bolt.Tx) error {
 		if ok, _ := BucketExists(tx, ManifestPath); !ok {
 			return nil
 		}
 
-		buf, version, err := readModel(tx)
+		mod, err := GetAny[model.Model](ctx, tx, ManifestPath, ModelKey)
 		switch {
 		case status.Code(err) == codes.NotFound:
 			return nil
 		case err != nil:
 			return err
-		}
-
-		var mod *model.Model
-
-		switch version {
-		case model.ModelVersion:
-			// The serialized model is on the latest version
-			var m model.Model
-			if err := json.Unmarshal(buf, &m); err != nil {
-				return err
-			}
-			mod = &m
-		default:
-			// need to reload the model from the manifest
-			mod, err = fromManifest(tx)
-			if err != nil {
-				return err
-			}
 		}
 
 		if err := s.mc.UpdateModel(mod); err != nil {
@@ -54,27 +36,4 @@ func (s *BoltDB) LoadModel() error {
 	})
 
 	return err
-}
-
-func readModel(tx *bolt.Tx) ([]byte, int, error) {
-	buf, err := GetKey(tx, ManifestPath, ModelKey)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	var m map[string]any
-	if err := json.Unmarshal(buf, &m); err != nil {
-		return nil, 0, err
-	}
-
-	return buf, int(m["version"].(float64)), nil
-}
-
-func fromManifest(tx *bolt.Tx) (*model.Model, error) {
-	manifest, err := GetKey(tx, ManifestPath, BodyKey)
-	if err != nil {
-		return nil, err
-	}
-
-	return v3.Load(bytes.NewReader(manifest))
 }

--- a/pkg/directory/directory.go
+++ b/pkg/directory/directory.go
@@ -28,7 +28,7 @@ import (
 
 // required minimum schema version, when the current version is lower, migration will be invoked to update to the minimum schema version required.
 const (
-	schemaVersion   string = "0.0.3"
+	schemaVersion   string = "0.0.4"
 	manifestVersion int    = 2
 	manifestName    string = "edge"
 )


### PR DESCRIPTION
I originally wrote the logic that reloads the model from the persisted manifest if the serialized model version is different from the current in `bdb.LoadModel`, which is called to load the model at startup, but that code path can't write the new model back to the store because it's running in the context of a read-only transaction.

This PR moves the logic to a new db migration that only runs once and is able to write the new model back to the store.