### PR TITLE
Assign slice back to out pointer after appends

### DIFF
--- a/pkg/bdb/scanner.go
+++ b/pkg/bdb/scanner.go
@@ -224,6 +224,8 @@ func ScanWithFilter[T any, M Message[T]](
 		}
 	}
 
+	*out = results
+
 	return nil
 }
 


### PR DESCRIPTION
ScanWithFilter appends to the array, which could return a new pointer, but it wasn't assigning it back to the `out` pointer.