### PR TITLE
ds.RelationIdentifier doesn't match empty subject relations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ replace github.com/bufbuild/protovalidate-go => github.com/bufbuild/protovalidat
 require (
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/aserto-dev/aserto-grpc v0.2.9
-	github.com/aserto-dev/azm v0.2.7-0.20250206205726-34d8ecbaa914
+	github.com/aserto-dev/azm v0.2.7-0.20250211003427-3254e6551a19
 	github.com/aserto-dev/errors v0.0.13
 	github.com/aserto-dev/go-directory v0.33.4
 	github.com/bufbuild/protovalidate-go v0.8.2

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ replace github.com/bufbuild/protovalidate-go => github.com/bufbuild/protovalidat
 require (
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/aserto-dev/aserto-grpc v0.2.9
-	github.com/aserto-dev/azm v0.2.5
+	github.com/aserto-dev/azm v0.2.7-0.20250206205726-34d8ecbaa914
 	github.com/aserto-dev/errors v0.0.13
 	github.com/aserto-dev/go-directory v0.33.4
 	github.com/bufbuild/protovalidate-go v0.8.2

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYW
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/aserto-dev/aserto-grpc v0.2.9 h1:17MKYEXaj8G7JwykcK9akCavVckNdXR/BvnLP3vdILQ=
 github.com/aserto-dev/aserto-grpc v0.2.9/go.mod h1:/86SRfxs45GX48X/AolNV1at/T6DRsjdPjjjC6CTVSI=
-github.com/aserto-dev/azm v0.2.5 h1:3OjcXbXUju5LjXYvG2VtUtvKhw3DB/l80BoX499uXLE=
-github.com/aserto-dev/azm v0.2.5/go.mod h1:vQfuAR4/mZXlHbu2S1Ogc38X7i+QTRSHJwATr8y9QrI=
+github.com/aserto-dev/azm v0.2.7-0.20250206205726-34d8ecbaa914 h1:qNZlVPjSOirP9N6K92K7MZjhGQ7eukuotTrkwfV1gBs=
+github.com/aserto-dev/azm v0.2.7-0.20250206205726-34d8ecbaa914/go.mod h1:vQfuAR4/mZXlHbu2S1Ogc38X7i+QTRSHJwATr8y9QrI=
 github.com/aserto-dev/errors v0.0.13 h1:STx3azu5kymLiCCIwtPxqKvTF9LeyE6O3YP634Tapp8=
 github.com/aserto-dev/errors v0.0.13/go.mod h1:0KXrbZV0/0mqyuUSv7IxuhIg0cHY0p1eOAXAWbXs1SM=
 github.com/aserto-dev/go-directory v0.33.4 h1:LhAL0RGKB7L2dm4hjAYVeuUhsu+EreYTUvu28t2OeXk=

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYW
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/aserto-dev/aserto-grpc v0.2.9 h1:17MKYEXaj8G7JwykcK9akCavVckNdXR/BvnLP3vdILQ=
 github.com/aserto-dev/aserto-grpc v0.2.9/go.mod h1:/86SRfxs45GX48X/AolNV1at/T6DRsjdPjjjC6CTVSI=
-github.com/aserto-dev/azm v0.2.7-0.20250206205726-34d8ecbaa914 h1:qNZlVPjSOirP9N6K92K7MZjhGQ7eukuotTrkwfV1gBs=
-github.com/aserto-dev/azm v0.2.7-0.20250206205726-34d8ecbaa914/go.mod h1:vQfuAR4/mZXlHbu2S1Ogc38X7i+QTRSHJwATr8y9QrI=
+github.com/aserto-dev/azm v0.2.7-0.20250211003427-3254e6551a19 h1:hsS0nPR3cMC2P3XSoPkedoyrn5zVLhxtRJ02oPW0cZc=
+github.com/aserto-dev/azm v0.2.7-0.20250211003427-3254e6551a19/go.mod h1:vQfuAR4/mZXlHbu2S1Ogc38X7i+QTRSHJwATr8y9QrI=
 github.com/aserto-dev/errors v0.0.13 h1:STx3azu5kymLiCCIwtPxqKvTF9LeyE6O3YP634Tapp8=
 github.com/aserto-dev/errors v0.0.13/go.mod h1:0KXrbZV0/0mqyuUSv7IxuhIg0cHY0p1eOAXAWbXs1SM=
 github.com/aserto-dev/go-directory v0.33.4 h1:LhAL0RGKB7L2dm4hjAYVeuUhsu+EreYTUvu28t2OeXk=

--- a/pkg/ds/relation.go
+++ b/pkg/ds/relation.go
@@ -37,7 +37,10 @@ func Relation(i *dsc3.Relation) *relation {
 }
 
 func RelationIdentifier(i *dsc3.RelationIdentifier) *relation {
-	return &relation{safe.Relation(i)}
+	return &relation{&safe.SafeRelation{
+		RelationIdentifier: i,
+		HasSubjectRelation: i.SubjectRelation != "",
+	}}
 }
 
 func GetRelation(i *dsr3.GetRelationRequest) *relations {


### PR DESCRIPTION
If a RelationIdentifier has an empty subject relation its filter should include all matching relations with or without a subject relation field.

Depends on:
* https://github.com/aserto-dev/azm/pull/69