### PR TITLE
fix migration 009

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aserto-dev/go-edge-ds
 
-go 1.23.11
+go 1.24
 
 toolchain go1.24.5
 

--- a/pkg/bdb/migrations/mig004/migrate.go
+++ b/pkg/bdb/migrations/mig004/migrate.go
@@ -18,8 +18,8 @@ const (
 var fnMap = []func(*zerolog.Logger, *bolt.DB, *bolt.DB) error{
 	common.CreateBucket(bdb.SystemPath),
 
-	common.CreateBucket(bdb.ManifestPath),
-	common.MigrateModel,
+	common.CreateBucket(bdb.ManifestPathV1),
+	common.MigrateModelV1,
 
 	common.CreateBucket(bdb.ObjectsPath),
 	common.CreateBucket(bdb.RelationsObjPath),

--- a/pkg/bdb/migrations/mig005/migrate.go
+++ b/pkg/bdb/migrations/mig005/migrate.go
@@ -18,8 +18,8 @@ const (
 var fnMap = []func(*zerolog.Logger, *bolt.DB, *bolt.DB) error{
 	common.CreateBucket(bdb.SystemPath),
 
-	common.CreateBucket(bdb.ManifestPath),
-	common.MigrateModel,
+	common.CreateBucket(bdb.ManifestPathV1),
+	common.MigrateModelV1,
 
 	common.CreateBucket(bdb.ObjectsPath),
 	common.CreateBucket(bdb.RelationsObjPath),

--- a/pkg/bdb/migrations/mig006/migrate.go
+++ b/pkg/bdb/migrations/mig006/migrate.go
@@ -18,8 +18,8 @@ const (
 var fnMap = []func(*zerolog.Logger, *bolt.DB, *bolt.DB) error{
 	common.CreateBucket(bdb.SystemPath),
 
-	common.CreateBucket(bdb.ManifestPath),
-	common.MigrateModel,
+	common.CreateBucket(bdb.ManifestPathV1),
+	common.MigrateModelV1,
 
 	common.CreateBucket(bdb.ObjectsPath),
 	common.CreateBucket(bdb.RelationsObjPath),

--- a/pkg/bdb/migrations/mig007/migrate.go
+++ b/pkg/bdb/migrations/mig007/migrate.go
@@ -26,9 +26,9 @@ var fnMap = []func(*zerolog.Logger, *bolt.DB, *bolt.DB) error{
 	common.DeleteBucket(bdb.SystemPath),
 	common.CreateBucket(bdb.SystemPath),
 
-	common.DeleteBucket(bdb.ManifestPath),
-	common.CreateBucket(bdb.ManifestPath),
-	updateManifest(bdb.ManifestPath),
+	common.DeleteBucket(bdb.ManifestPathV1),
+	common.CreateBucket(bdb.ManifestPathV1),
+	updateManifest(bdb.ManifestPathV1),
 
 	common.DeleteBucket(bdb.ObjectsPath),
 	common.CreateBucket(bdb.ObjectsPath),

--- a/pkg/bdb/migrations/mig008/migrate.go
+++ b/pkg/bdb/migrations/mig008/migrate.go
@@ -18,8 +18,8 @@ const (
 var fnMap = []func(*zerolog.Logger, *bolt.DB, *bolt.DB) error{
 	common.CreateBucket(bdb.SystemPath),
 
-	common.CreateBucket(bdb.ManifestPath),
-	common.MigrateModel,
+	common.CreateBucket(bdb.ManifestPathV1),
+	common.MigrateModelV1,
 
 	common.CreateBucket(bdb.ObjectsPath),
 	common.CreateBucket(bdb.RelationsObjPath),

--- a/pkg/bdb/migrations/mig009/migrate.go
+++ b/pkg/bdb/migrations/mig009/migrate.go
@@ -34,9 +34,9 @@ const (
 var fnMap = []func(*zerolog.Logger, *bolt.DB, *bolt.DB) error{
 	common.CreateBucket(bdb.SystemPath),
 
-	common.DeleteBucket(bdb.ManifestPath),
+	common.DeleteBucket(bdb.ManifestPathV1),
 	common.CreateBucket(bdb.ManifestPathV2),
-	updateManifest(bdb.ManifestPath, bdb.ManifestPathV2),
+	updateManifest(bdb.ManifestPathV1, bdb.ManifestPathV2),
 
 	common.CreateBucket(bdb.ObjectsPath),
 	common.CreateBucket(bdb.RelationsObjPath),

--- a/pkg/bdb/path.go
+++ b/pkg/bdb/path.go
@@ -2,22 +2,23 @@ package bdb
 
 type Path []string
 
+const (
+	manifestName      string = "default"
+	manifestVersionV1 string = "0.0.1" // OBSOLETE per migration 0.0.9
+)
+
 var (
 	SystemPath        Path = []string{"_system"}
-	ManifestPath      Path = []string{"_manifest", ManifestName, ManifestVersion}
-	ManifestPathV2    Path = []string{"_manifest", ManifestName}
-	ObjectTypesPath   Path = []string{"object_types"}
-	PermissionsPath   Path = []string{"permissions"}
-	RelationTypesPath Path = []string{"relation_types"}
+	ManifestPath      Path = ManifestPathV2                                         // current path
+	ManifestPathV1    Path = []string{"_manifest", manifestName, manifestVersionV1} // migration path V1, OBSOLETE per migration 0.0.8
+	ManifestPathV2    Path = []string{"_manifest", manifestName}                    // migration path V2
+	ObjectTypesPath   Path = []string{"object_types"}                               // OBSOLETE
+	PermissionsPath   Path = []string{"permissions"}                                // OBSOLETE
+	RelationTypesPath Path = []string{"relation_types"}                             // OBSOLETE
 	ObjectsPath       Path = []string{"objects"}
 	RelationsSubPath  Path = []string{"relations_sub"}
 	RelationsObjPath  Path = []string{"relations_obj"}
 	MetadataKey            = []byte("metadata")
 	BodyKey                = []byte("body")
 	ModelKey               = []byte("model")
-)
-
-const (
-	ManifestName    string = "default"
-	ManifestVersion string = "0.0.1"
 )

--- a/pkg/ds/manifest.go
+++ b/pkg/ds/manifest.go
@@ -49,11 +49,11 @@ func (m *manifest) Get(ctx context.Context, tx *bolt.Tx) (*manifest, error) {
 // Get, hydrates the model cache from the _manifest
 // _metadata/{name}/{version}/model.
 func (m *manifest) GetModel(ctx context.Context, tx *bolt.Tx) (*model.Model, error) {
-	if ok, _ := bdb.BucketExists(tx, bdb.ManifestPath); !ok {
+	if ok, _ := bdb.BucketExists(tx, bdb.ManifestPathV2); !ok {
 		return nil, bdb.ErrPathNotFound
 	}
 
-	mod, err := bdb.GetAny[model.Model](ctx, tx, bdb.ManifestPath, bdb.ModelKey)
+	mod, err := bdb.GetAny[model.Model](ctx, tx, bdb.ManifestPathV2, bdb.ModelKey)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ds/manifest.go
+++ b/pkg/ds/manifest.go
@@ -49,11 +49,11 @@ func (m *manifest) Get(ctx context.Context, tx *bolt.Tx) (*manifest, error) {
 // Get, hydrates the model cache from the _manifest
 // _metadata/{name}/{version}/model.
 func (m *manifest) GetModel(ctx context.Context, tx *bolt.Tx) (*model.Model, error) {
-	if ok, _ := bdb.BucketExists(tx, bdb.ManifestPathV2); !ok {
+	if ok, _ := bdb.BucketExists(tx, bdb.ManifestPath); !ok {
 		return nil, bdb.ErrPathNotFound
 	}
 
-	mod, err := bdb.GetAny[model.Model](ctx, tx, bdb.ManifestPathV2, bdb.ModelKey)
+	mod, err := bdb.GetAny[model.Model](ctx, tx, bdb.ManifestPath, bdb.ModelKey)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/check_test.go
+++ b/tests/check_test.go
@@ -1,7 +1,6 @@
 package tests_test
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -28,7 +27,7 @@ func BenchmarkCheckSerial(b *testing.B) {
 
 	setupBenchmark(b, client)
 
-	ctx := context.Background()
+	ctx := b.Context()
 
 	b.ResetTimer()
 
@@ -50,7 +49,7 @@ func BenchmarkCheckParallel(b *testing.B) {
 
 	setupBenchmark(b, client)
 
-	ctx := context.Background()
+	ctx := b.Context()
 
 	b.ResetTimer()
 
@@ -76,7 +75,7 @@ func BenchmarkCheckParallelChunks(b *testing.B) {
 
 	setupBenchmark(b, client)
 
-	ctx := context.Background()
+	ctx := b.Context()
 
 	var chunks [][]*dsr3.CheckRequest
 
@@ -111,7 +110,7 @@ func setupBenchmark(b *testing.B, client *server.TestEdgeClient) {
 	assert.NoError(deleteManifest(client))
 	assert.NoError(setManifest(client, manifest))
 
-	g, iCtx := errgroup.WithContext(context.Background())
+	g, iCtx := errgroup.WithContext(b.Context())
 	stream, err := client.V3.Importer.Import(iCtx)
 	assert.NoError(err)
 

--- a/tests/manifest_test.go
+++ b/tests/manifest_test.go
@@ -186,7 +186,7 @@ func testGetManifest(client *server.TestEdgeClient, manifest string) func(*testi
 
 func testGetModel(client *server.TestEdgeClient) func(*testing.T) {
 	return func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		hdr := metadata.New(map[string]string{"aserto-model-request": "model-only"})
 		ctx = metadata.NewOutgoingContext(ctx, hdr)
 

--- a/tests/runner_test.go
+++ b/tests/runner_test.go
@@ -172,7 +172,7 @@ func testRunner(t *testing.T, tcs []*TestCase) {
 	client, cleanup := testInit()
 	t.Cleanup(cleanup)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	manifest, err := os.ReadFile("./manifest_v3_test.yaml")
 	require.NoError(t, err)

--- a/tests/search_test.go
+++ b/tests/search_test.go
@@ -1,7 +1,6 @@
 package tests_test
 
 import (
-	"context"
 	"runtime"
 	"testing"
 
@@ -22,7 +21,7 @@ func BenchmarkSearchSerial(b *testing.B) {
 
 	setupBenchmark(b, client)
 
-	ctx := context.Background()
+	ctx := b.Context()
 
 	b.ResetTimer()
 
@@ -44,7 +43,7 @@ func BenchmarkSearchParallelChunks(b *testing.B) {
 
 	setupBenchmark(b, client)
 
-	ctx := context.Background()
+	ctx := b.Context()
 
 	var chunks [][]*dsr3.GetGraphRequest
 


### PR DESCRIPTION
Migration 009 did not switch to the new manifest path, resulting in a missing model when migrating from a 004 migration state to 009.